### PR TITLE
🧪 Test : 빌드 실패 이슈에 관한 테스트 코드 수정

### DIFF
--- a/src/test/java/com/hanbang/e/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/hanbang/e/order/controller/OrderControllerTest.java
@@ -3,7 +3,6 @@ package com.hanbang.e.order.controller;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +61,7 @@ class OrderControllerTest {
 	@Test
 	void doOrderTest() throws JsonProcessingException {
 		/* given - 데이터 준비 */
-		headers.add("Authorization", jwtUtil.createToken(1L));
+
 		Member dummyMember = new Member("tj087@naver.com", "1234", "제주시");
 		Product product1 = Product.builder()
 			.productName("아이폰11")
@@ -73,6 +72,7 @@ class OrderControllerTest {
 			.onSale(true)
 			.build();
 		memberRepository.save(dummyMember);
+		headers.add("Authorization", jwtUtil.createToken(dummyMember.getMemberId()));
 		productRepository.save(product1);
 
 		OrderReq order = new OrderReq(1);
@@ -80,7 +80,7 @@ class OrderControllerTest {
 
 		/* when - 테스트 실행 */
 		HttpEntity<String> request = new HttpEntity<>(body, headers);
-		ResponseEntity<String> response = rt.exchange("/api/order?productId=1", HttpMethod.POST, request, String.class);
+		ResponseEntity<String> response = rt.exchange("/api/order?productId="+product1.getProductId(), HttpMethod.POST, request, String.class);
 
 		/* then - 검증 */
 		DocumentContext dc = JsonPath.parse(response.getBody());
@@ -96,7 +96,6 @@ class OrderControllerTest {
 	@Test
 	void getMyOrderListTest() throws JsonProcessingException {
 		/* given - 데이터 준비 */
-		headers.add("Authorization", jwtUtil.createToken(1L));
 		Product product1 = new Product("화장품", 23000L, "http://화장품.jpg", 50, 50, true);
 		productRepository.save(product1);
 
@@ -108,6 +107,7 @@ class OrderControllerTest {
 
 		Member member = new Member("mina@naver.com", "12345", "제주도");
 		memberRepository.save(member);
+		headers.add("Authorization", jwtUtil.createToken(member.getMemberId()));
 
 		Orders order1 = Orders.builder()
 			.destination(member.getAddress())
@@ -149,7 +149,7 @@ class OrderControllerTest {
 		Integer quantity = dc.read("$.data[1].quantity");
 		Integer productPrice = dc.read("$.data[1].productPrice");
 		Integer totalPrice = dc.read("$.data[1].totalPrice");
-		Integer productId = dc.read("$.data[1].productId");
+		Long productId = dc.read("$.data[1].productId", Long.class);
 		String productName = dc.read("$.data[1].productName");
 		String img = dc.read("$.data[1].img");
 
@@ -160,7 +160,7 @@ class OrderControllerTest {
 		assertThat(quantity).isEqualTo(order2.getQuantity());
 		assertThat(productPrice).isEqualTo(36000);
 		assertThat(totalPrice).isEqualTo(72000);
-		assertThat(productId).isEqualTo(2);
+		assertThat(productId).isEqualTo(order2.getProduct().getProductId());
 		assertThat(productName).isEqualTo(order2.getProduct().getProductName());
 		assertThat(img).isEqualTo(order2.getProduct().getImg());
 
@@ -170,7 +170,6 @@ class OrderControllerTest {
 	@Test
 	public void deleteOrderTest() throws JsonProcessingException {
 		/* given - 데이터 준비 */
-		headers.add("Authorization", jwtUtil.createToken(1L));
 		Member dummyMember = new Member("tj087@naver.com", "1234", "제주시");
 		Product product1 = Product.builder()
 			.productName("아이폰11")
@@ -181,6 +180,7 @@ class OrderControllerTest {
 			.onSale(true)
 			.build();
 		memberRepository.save(dummyMember);
+		headers.add("Authorization", jwtUtil.createToken(dummyMember.getMemberId()));
 		productRepository.save(product1);
 		Orders dummyOrder = Orders.builder()
 			.destination(dummyMember.getAddress())

--- a/src/test/java/com/hanbang/e/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/hanbang/e/product/controller/ProductControllerTest.java
@@ -41,8 +41,42 @@ class ProductControllerTest {
 		headers.setContentType(MediaType.APPLICATION_JSON);
 	}
 
-	@BeforeEach
-	public void dataSet() {
+	@AfterEach
+	public void dataClear() {
+		productRepository.deleteAll();
+	}
+
+	@DisplayName("상품 상세조회")
+	@Test
+	public void getProductDetailsTest() {
+		/* given - 데이터 준비 */
+		Product product1 = Product.builder()
+			.productName("아이폰11")
+			.price(500000L)
+			.img("http....")
+			.stock(10)
+			.sales(50)
+			.onSale(true)
+			.build();
+		productRepository.save(product1);
+
+		/* when - 테스트 실행 */
+		HttpEntity<String> request = new HttpEntity<>(null, headers);
+		ResponseEntity<String> response = rt.exchange("/api/product/details/"+ product1.getProductId(), HttpMethod.GET, request, String.class);
+
+		/* then - 검증 */
+		DocumentContext dc = JsonPath.parse(response.getBody());
+		String result = dc.read("$.result");
+		String name = dc.read("$.data.name");
+
+		assertThat(result).isEqualTo("success");
+		assertThat(name).isEqualTo("아이폰11");
+	}
+
+	@DisplayName("상품 검색하기, 낮은 가격순 조회")
+	@Test
+	public void searchProductOrderByLowToHighTest() {
+		/* given - 데이터 준비 */
 		Product product1 = Product.builder()
 			.productName("아이폰11")
 			.price(500000L)
@@ -67,39 +101,10 @@ class ProductControllerTest {
 			.sales(75)
 			.onSale(true)
 			.build();
+
 		productRepository.save(product1);
 		productRepository.save(product2);
 		productRepository.save(product3);
-	}
-
-	@AfterEach
-	public void dataClear() {
-		productRepository.deleteAll();
-	}
-
-	@DisplayName("상품 상세조회")
-	@Test
-	public void getProductDetailsTest() {
-		/* given - 데이터 준비 */
-
-		/* when - 테스트 실행 */
-		HttpEntity<String> request = new HttpEntity<>(null, headers);
-		ResponseEntity<String> response = rt.exchange("/api/product/details/1", HttpMethod.GET, request, String.class);
-
-		System.out.println(response);
-		/* then - 검증 */
-		DocumentContext dc = JsonPath.parse(response.getBody());
-		String result = dc.read("$.result");
-		String name = dc.read("$.data.name");
-
-		assertThat(result).isEqualTo("success");
-		assertThat(name).isEqualTo("아이폰11");
-	}
-
-	@DisplayName("상품 검색하기, 낮은 가격순 조회")
-	@Test
-	public void searchProductOrderByLowToHighTest() {
-		/* given - 데이터 준비 */
 
 		/* when - 테스트 실행 */
 		HttpEntity<String> request = new HttpEntity<>(null, headers);
@@ -124,6 +129,34 @@ class ProductControllerTest {
 	@Test
 	public void searchProductOrderByHighToLowTest() {
 		/* given - 데이터 준비 */
+		Product product1 = Product.builder()
+			.productName("아이폰11")
+			.price(500000L)
+			.img("http....")
+			.stock(10)
+			.sales(50)
+			.onSale(true)
+			.build();
+		Product product2 = Product.builder()
+			.productName("아이폰12")
+			.price(1000000L)
+			.img("http....")
+			.stock(15)
+			.sales(100)
+			.onSale(true)
+			.build();
+		Product product3 = Product.builder()
+			.productName("아이폰13")
+			.price(1200000L)
+			.img("http....")
+			.stock(10)
+			.sales(75)
+			.onSale(true)
+			.build();
+
+		productRepository.save(product1);
+		productRepository.save(product2);
+		productRepository.save(product3);
 
 		/* when - 테스트 실행 */
 		HttpEntity<String> request = new HttpEntity<>(null, headers);
@@ -148,6 +181,34 @@ class ProductControllerTest {
 	@Test
 	public void searchProductOrderByBestSellingTest() {
 		/* given - 데이터 준비 */
+		Product product1 = Product.builder()
+			.productName("아이폰11")
+			.price(500000L)
+			.img("http....")
+			.stock(10)
+			.sales(50)
+			.onSale(true)
+			.build();
+		Product product2 = Product.builder()
+			.productName("아이폰12")
+			.price(1000000L)
+			.img("http....")
+			.stock(15)
+			.sales(100)
+			.onSale(true)
+			.build();
+		Product product3 = Product.builder()
+			.productName("아이폰13")
+			.price(1200000L)
+			.img("http....")
+			.stock(10)
+			.sales(75)
+			.onSale(true)
+			.build();
+
+		productRepository.save(product1);
+		productRepository.save(product2);
+		productRepository.save(product3);
 
 		/* when - 테스트 실행 */
 		HttpEntity<String> request = new HttpEntity<>(null, headers);


### PR DESCRIPTION
<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.

✨ Feat : 새로운 기능
🔨️ Refactor : 코드 리팩토링
🐎 Perf : 성능을 향상
🐛 Fix : 버그를 고칠 때
🧪 Test : 테스트 코드
🚜 Rename : 파일 이름 변경 혹은 구조를 변경
🚀 Release : 배포 / 개발 작업과 관련된 모든 것
🔥 Remove : 코드 또는 파일 제거
📚 Docs : 문서
📝 Chore : 사소한 코드 또는 언어를 변경 기타 변경사항 (빌드 스크립트 수정, 패키지 매니징 설정 등)

-->

## PR 타입
<!-- 어떤 유형의 PR인지 체크해주세요. -->

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance Improvement
- [ ] Bugfix
- [x] Test Code
- [ ] Code style update (formatting, local variables)
- [ ] Other... Please describe:



## 개요 
이슈 #32 에 명시된 문제를 해결하기 위해서 테스트 코드 수정, 처음에는 테스트 환경의 문제인 줄 알았으나, 확인결과 각 테스트의 검증 단계에서 우리가 원하는 `id`값이 실제로 나온 `id`값과 일치하지 않아 테스트가 실패로 처리되는 것이었음. 

현재 프로젝트의 Entity의 기본키 매핑은 다음과 같은 자동 생성전략을 사용 
```java
@GeneratedValue(strategy = GenerationType.IDENTITY)
```

하지만 테스트코드에서는 이를 상관하지않고 검증단계에서 별다른 처리 없이 항상 가장 처음 저장되었다고 생각해 항상 데이터의 기본키가 `1L`을 불러와 검증을 시도했음. 그 결과 각각의 도메인의 테스트에서는 문제가 없었지만 모든 테스트를 실행하는 과정에서 테스트가 실패하게 되었음.

이를 해결하기 위해 테스트코드에서 `1L`과 같이 고정적인 기본키를 사용하는 것이 아닌 given(데이터 준비 과정)에서 데이터를 저장할 때의 `id`값을 가져와 then(검증 단계)에서 같은 `id`값이 넘어오는지 확인하도록 수정, 결과적으로 테스트코드가 `id`값에 영향을 받지 않도록 변경

## 작업 및 변경 사항 
- OrderControllerTest 코드 수정
- ProductControllerTest 코드 수정

### 테스트 결과 
- 테스트 통과


close #32 