### PR TITLE
✨ Feat : 동시성 제어시 Lock을  Annotation 로직 변경

### DIFF
--- a/src/main/java/com/hanbang/e/common/annotation/distributeLock/DistributeLock.java
+++ b/src/main/java/com/hanbang/e/common/annotation/distributeLock/DistributeLock.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 public @interface DistributeLock {
     String key(); // 락의 이름
 
+    String name();
     TimeUnit timeUnit() default TimeUnit.SECONDS; // 시간 단위 설정(초)
 
     long waitTime() default 5L; // 락을 획득하기 위한 대기 시간

--- a/src/main/java/com/hanbang/e/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hanbang/e/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -21,6 +22,14 @@ public class GlobalExceptionHandler {
 	public ResponseEntity IllegalArgumentExceptionHandler(Exception e) {
 		logger.error("", e);
 		ResponseDto response = new ResponseDto("fail", e.getMessage(), null);
+
+		return new ResponseEntity(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(value = DataIntegrityViolationException.class)
+	public ResponseEntity DataIntegrityViolationExceptionHandler(Exception e) {
+		logger.error("", e);
+		ResponseDto response = new ResponseDto("fail", "시스템 오류, 다시 시도해주세요", null);
 
 		return new ResponseEntity(response, HttpStatus.BAD_REQUEST);
 	}

--- a/src/main/java/com/hanbang/e/member/entity/Member.java
+++ b/src/main/java/com/hanbang/e/member/entity/Member.java
@@ -18,7 +18,7 @@ public class Member {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long memberId;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String email;
 
 	@Column(nullable = false)

--- a/src/main/java/com/hanbang/e/member/service/MemberService.java
+++ b/src/main/java/com/hanbang/e/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.hanbang.e.member.service;
 
-import com.hanbang.e.common.annotation.distributeLock.DistributeLock;
 import com.hanbang.e.common.jwt.JwtUtil;
 import com.hanbang.e.member.dto.MemberCreateReq;
 import com.hanbang.e.member.dto.MemberLoginReq;
@@ -24,7 +23,7 @@ public class MemberService {
 
     private final JwtUtil jwtUtil;
 
-    @DistributeLock(key = "#Member")
+    @Transactional
     public void signup(MemberCreateReq memberCreateReq) {
         memberRepository.findByEmail(memberCreateReq.getEmail())
                 .ifPresent(m -> {

--- a/src/main/java/com/hanbang/e/order/service/OrderService.java
+++ b/src/main/java/com/hanbang/e/order/service/OrderService.java
@@ -28,7 +28,7 @@ public class OrderService {
 	private final MemberRepository memberRepository;
 	private final ProductRepository productRepository;
 
-	@DistributeLock(key = "#Order")
+	@DistributeLock(key = "#productId", name = "productId")
 	public void insertOrder(Long memberId, Long productId, OrderReq orderReq) {
 
 		Member member = memberRepository.findById(memberId)
@@ -77,7 +77,7 @@ public class OrderService {
 		return orderRespList;
 	}
 
-	@DistributeLock(key = "#Order")
+	@Transactional
 	public void deleteOrder(Long memberId, Long orderId) {
 
 		Orders orders = orderRepository.findById(orderId)
@@ -87,10 +87,13 @@ public class OrderService {
 			throw new IllegalArgumentException(NOT_HAVE_PERMISSION_DELETE_MSG.getMsg());
 		}
 
-		Product cancledProduct = orders.getProduct();
-		cancledProduct.orderCancel(orders.getQuantity());
-		
+		orderCancel(orders.getProduct().getProductId(), orders.getQuantity());
 		orderRepository.deleteById(orderId);
 	}
 
+	@DistributeLock(key = "#productId", name = "productId")
+	private void orderCancel(Long productId, int quantity) {
+		Product product = productRepository.findById(productId).get();
+		product.orderCancel(quantity);
+	}
 }

--- a/src/test/java/com/hanbang/e/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/hanbang/e/member/repository/MemberRepositoryTest.java
@@ -31,7 +31,7 @@ public class MemberRepositoryTest {
     @DisplayName("회원가입")
     public void createMemberTest() {
         /* given - 데이터 준비 */
-        Member member = new Member("이메일","비밀번호","주소");
+        Member member = new Member("member1","비밀번호","주소");
 
         /* when - 테스트 실행 */
         Member member1 = memberRepository.save(member);

--- a/src/test/java/com/hanbang/e/order/service/OrderServiceDecreaseLockTest.java
+++ b/src/test/java/com/hanbang/e/order/service/OrderServiceDecreaseLockTest.java
@@ -87,12 +87,10 @@ public class OrderServiceDecreaseLockTest {
     @DisplayName("주문취소 동시에 100개의요청")
     public void deleteOrderAtSameTime() throws InterruptedException {
         /* 상품 정보 생성 */
-        Product product = new Product("맥북프로", 1000000L, "img", 0, 100, true);
-        productRepository.saveAndFlush(product);
+        Product product = productRepository.findAll().get(0);
 
         /* 회원 정보 생성 */
-        Member member = new Member("yj0718@gmail.com", "dPwls12!", "address");
-        memberRepository.saveAndFlush(member);
+        Member member = memberRepository.findAll().get(0);
 
         /* 주문 정보 생성 */
         for (int i = 0; i < 100; i++) {
@@ -118,7 +116,8 @@ public class OrderServiceDecreaseLockTest {
         }
         latch.await();
 
-        Long resultOrders = orderRepository.count();
-        assertThat(resultOrders).isEqualTo(orderRepository.count());
+        assertThat(orderRepository.count()).isEqualTo(0);
+        assertThat(product.getStock()).isEqualTo(100);
+        assertThat(product.getSales()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.

✨ Feat : 새로운 기능
🔨️ Refactor : 코드 리팩토링
🐎 Perf : 성능을 향상
🐛 Fix : 버그를 고칠 때
🧪 Test : 테스트 코드
🚜 Rename : 파일 이름 변경 혹은 구조를 변경
🚀 Release : 배포 / 개발 작업과 관련된 모든 것
🔥 Remove : 코드 또는 파일 제거
📚 Docs : 문서
📝 Chore : 사소한 코드 또는 언어를 변경 기타 변경사항 (빌드 스크립트 수정, 패키지 매니징 설정 등)

-->

## PR 타입
<!-- 어떤 유형의 PR인지 체크해주세요. -->

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Performance Improvement
- [ ] Bugfix
- [x] Test Code
- [ ] Code style update (formatting, local variables)
- [ ] Other... Please describe:



## 개요 
- 기존의 Lock을 거는 방식은 해당 ID만을 가지고 Lock을 거는 방식이었으나 이렇게 될 경우 다른 ID지만 같은 값일 경우, 예를 들어 productID와 orderID의 같이 둘다 1일 경우에도 같은 락을 걸어버리는 문제가 있었음. 이를 해결하기 위해 `@DistributeLock`의 로직을 수정


## 작업 및 변경 사항 
- `@DistributeLock`을 사용시 붙여야할 속성(name) 추가 이 속성을 통해 Lock을 거는 대상을 특정시켜 정확한 동시성 제어를 가능케함
```java
// LOCK을 걸면 "RLOCK_productID_1"의 형태로 LOCK이 걸림
@DistributeLock(key = "#productId", name = "productId")
```
- 테스트 코드 수정
- 동시에 같은 Email로 회원가입 시 동시성 제어 방법을 Entity에 Uniqe속성을 넣어 DB로 둘다 저장되지 않도록 변경

### 테스트 결과 
![image](https://user-images.githubusercontent.com/28504937/215146290-3499db1e-3096-4387-9df0-b5c6d42b9b08.png)

close #79 
