### PR TITLE
✨ Feat : 락획득 실패시 예외처리 추가

### DIFF
--- a/src/main/java/com/hanbang/e/common/annotation/distributeLock/DistributeLockAop.java
+++ b/src/main/java/com/hanbang/e/common/annotation/distributeLock/DistributeLockAop.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
 
+import static com.hanbang.e.common.exception.ExceptionMessage.ORDER_FAIL_MSG;
+
 /*
 - @DistributeLock 을 선언한 메소드를 호출했을때 실행되는 aop클래스
  */
@@ -43,7 +45,8 @@ public class DistributeLockAop {
             // Redisson의 tryLock method를 이용해 Lock 획득을 시도 (획득 실패시 Lock이 해제 될 때까지 subscribe)
             boolean available = rLock.tryLock(distributeLock.waitTime(), distributeLock.leaseTime(), distributeLock.timeUnit());
             if (!available) {
-                return false;
+                // 락 획득 실패 시의 예외처리.
+                throw new IllegalArgumentException(ORDER_FAIL_MSG.getMsg());
             }
 
             log.info("get lock success {}" , key);

--- a/src/main/java/com/hanbang/e/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/hanbang/e/common/exception/ExceptionMessage.java
@@ -17,7 +17,8 @@ public enum ExceptionMessage {
 	NOT_SELL_PRODUCT_MSG("현재 판매하는 상품이 아닙니다."),
 	PRODUCT_OUTOF_STOCK_MSG("현재 재고가 없는 상품입니다."),
 	BE_IN_STOCK_CHECK_MSG("현재 남은 재고는 %d개 입니다."),
-	NOT_HAVE_PERMISSION_DELETE_MSG("주문 삭제 권한이 없습니다.");
+	NOT_HAVE_PERMISSION_DELETE_MSG("주문 삭제 권한이 없습니다."),
+	ORDER_FAIL_MSG("너무 많은 요청으로 인해 상품 주문에 실패했습니다. 다시 시도해주세요.");
 
 
 	private final String msg;


### PR DESCRIPTION
Resolves: #87

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.

✨ Feat : 새로운 기능
🔨️ Refactor : 코드 리팩토링
🐎 Perf : 성능을 향상
🐛 Fix : 버그를 고칠 때
🧪 Test : 테스트 코드
🚜 Rename : 파일 이름 변경 혹은 구조를 변경
🚀 Release : 배포 / 개발 작업과 관련된 모든 것
🔥 Remove : 코드 또는 파일 제거
📚 Docs : 문서
📝 Chore : 사소한 코드 또는 언어를 변경 기타 변경사항 (빌드 스크립트 수정, 패키지 매니징 설정 등)

-->

## PR 타입
<!-- 어떤 유형의 PR인지 체크해주세요. -->

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance Improvement
- [ ] Bugfix
- [ ] Test Code
- [ ] Code style update (formatting, local variables)
- [ ] Other... Please describe:



## 개요 
- 한번에 많은 요청이 몰릴 시 락 획득을 위한 대기시간이 요청 전체 대기시간을 초과하여 결과적으로 락획득을 실패해버리는 경우가 발생. 동시성 문제를 해결하기위해서는 락을 거는 것에 대해서는 추가적으로 할 수 있는 부분은 대기시간을 늘리는 것이지만 이보다는 대기시간 초과시 사용자로 하여금 실패여부와 이유를 알 수 있도록 예외처리 추가



## 작업 및 변경 사항 
- ExceptionMessage추가 (`ORDER_FAIL_MSG`)
- `DistributeLockAop`의 락 획득 실패 예외처리 추가


### 테스트 결과 
![image](https://user-images.githubusercontent.com/28504937/216582880-2e850fd5-4cab-4848-9887-3746de76b5d4.png)



close #87 
